### PR TITLE
Adjust for circular list

### DIFF
--- a/DoublyLinkedList.js
+++ b/DoublyLinkedList.js
@@ -24,6 +24,10 @@ class DoublyLinkedList {
       newNode.next = this.head;
       this.head.previous = newNode;
       this.head = newNode;
+      if (this.isCircular) {
+        newNode.previous = this.tail;
+        this.tail.next = newNode;
+      }
     }
     this.length++;
   }

--- a/DoublyLinkedList.js
+++ b/DoublyLinkedList.js
@@ -42,6 +42,10 @@ class DoublyLinkedList {
       this.tail.next = newNode;
       newNode.previous = this.tail;
       this.tail = newNode;
+      if (this.isCircular) {
+        newNode.next = this.head;
+        this.head.previous = newNode;
+      }
     }
     this.length++;
   }

--- a/DoublyLinkedList.test.js
+++ b/DoublyLinkedList.test.js
@@ -24,6 +24,21 @@ describe("#prependElement", () => {
       expect(dll.length).toBe(2);
     });
   });
+  describe("test 3: when the list is circular", () => {
+    test("it adds the element at the beginning of the list then reconnects the loop", () => {
+      const dll = new DoublyLinkedList();
+      dll.prependElement(10);
+      dll.prependElement(20);
+      dll.convertToCircularDoublyLinkedList();
+      dll.prependElement(30);
+
+      expect(dll.head.value).toBe(30);
+      expect(dll.tail.value).toBe(10);
+      expect(dll.head.previous.value).toBe(10);
+      expect(dll.tail.next.value).toBe(30);
+      expect(dll.length).toBe(3);
+    });
+  });
 });
 
 describe("#appendElement", () => {

--- a/DoublyLinkedList.test.js
+++ b/DoublyLinkedList.test.js
@@ -271,7 +271,7 @@ describe("#removeFirstElement", () => {
       dll.appendElement(20);
       dll.appendElement(30);
       dll.appendElement(40);
-      dll.isCircular = true;
+      dll.convertToCircularDoublyLinkedList();
       dll.removeFirstElement();
 
       expect(dll.head.value).toBe(20);
@@ -313,7 +313,7 @@ describe("#removeLastElement", () => {
       dll.appendElement(20);
       dll.appendElement(30);
       dll.appendElement(40);
-      dll.isCircular = true;
+      dll.convertToCircularDoublyLinkedList();
       dll.removeLastElement();
 
       expect(dll.tail.value).toBe(30);

--- a/DoublyLinkedList.test.js
+++ b/DoublyLinkedList.test.js
@@ -63,6 +63,21 @@ describe("#appendElement", () => {
       expect(dll.length).toBe(2);
     });
   });
+  describe("test 3: when the list is circular", () => {
+    test("it adds the element at the end of the list then reconnects the loop", () => {
+      const dll = new DoublyLinkedList();
+      dll.appendElement(10);
+      dll.appendElement(20);
+      dll.convertToCircularDoublyLinkedList();
+      dll.appendElement(30);
+
+      expect(dll.head.value).toBe(10);
+      expect(dll.tail.value).toBe(30);
+      expect(dll.head.previous.value).toBe(30);
+      expect(dll.tail.next.value).toBe(10);
+      expect(dll.length).toBe(3);
+    });
+  });
 });
 
 describe("#getElementAtIndex", () => {


### PR DESCRIPTION
This adjusts prependElement and appendElement when list is circular. Also adjusts tests for removeFirstElement and removeLastElement to call convertToCircularDoublyLinkedList instead of setting isCircular directly.